### PR TITLE
IO work: ``/include/stdio.h``, ``systemio`` libs

### DIFF
--- a/include/stdio.c
+++ b/include/stdio.c
@@ -1,0 +1,17 @@
+#include "stdio.h"
+#include "../drivers/vga.h"
+
+void printf(char* text) {
+    /*
+    VERY IMPORTANT TO NOTE:
+    
+    ANSI escapes are not avaliable while the kernel is still in it's baby state.
+    VGA color can probably be implemented using a little more code, but let's be conservative
+    while the system is in it's baby stages.
+    */
+    vga_print_string(text);
+}
+
+char* scanf() {
+    // Used when keyboard driver is added. Should be pretty basic to implement.
+}

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -1,0 +1,2 @@
+void printf(char* text);
+char* scanf();

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -8,11 +8,13 @@
 #include "main.h"
 #include "../drivers/vga.h"
 #include "../drivers/port.h"
-#include <stdio.h>
+#include "systemio/systemio.h"
+#include "stdio.h" // :: There is no standard yet, either switch to "stdio.h" or comment it out until
+//                    :: there is implementation for it
 
 void launch_kernel(void) {
     vga_initialize();
-    vga_print_string("Kernel loaded.\n");
+    out("kernel", "info", "Kernel has initialized");
     print_log(); //hehehe
-    vga_print_string("Welcome RawBerry!\n");
+    printf("Welcome to RawBerry!\n");
 }

--- a/kernel/systemio/systemio.c
+++ b/kernel/systemio/systemio.c
@@ -1,0 +1,9 @@
+#include "systemio.h"
+#include "../drivers/vga.h"
+
+void out(char* PROCESS_NAME, char* OUT_TYPE, char* TEXT) {
+    // May be pretty stupid to make the output look pretty, but it will be way better
+    // when trying to debug.
+
+    vga_print_string(("[%s/%s]: %s", PROCESS_NAME, OUT_TYPE, TEXT)); // just to be safe, double ()()
+}

--- a/kernel/systemio/systemio.h
+++ b/kernel/systemio/systemio.h
@@ -1,0 +1,1 @@
+void out(char* PROCESS_NAME, char* TEXT)


### PR DESCRIPTION
``include/stdio.h`` / ``include/stdio.c``:
- Starting work on stdio.h. Not much need for a driver for it at this point, but working on it now will help build some early utilities before any big switch to a C compiler.
``kernel/systemio/systemio.h`` / ``kernel/systemio/systemio.c``:
- Standardizing system output. It seems pretty insignificant, but using some standard for it will make debugging way easier in the future when you're dealing with hundreds of files.