### PR TITLE
systemio: Fixing code samples for kernel, ``SYSTEMIO_OUT_TYPE`` enum

### DIFF
--- a/kernel/main.c
+++ b/kernel/main.c
@@ -14,7 +14,7 @@
 
 void launch_kernel(void) {
     vga_initialize();
-    out("kernel", "info", "Kernel has initialized");
+    out("kernel", SYSTEMIO_OUT_INFO, "Kernel has initialized");
     print_log(); //hehehe
     printf("Welcome to RawBerry!\n");
 }

--- a/kernel/systemio/systemio.c
+++ b/kernel/systemio/systemio.c
@@ -1,9 +1,25 @@
 #include "systemio.h"
 #include "../drivers/vga.h"
 
-void out(char* PROCESS_NAME, char* OUT_TYPE, char* TEXT) {
+void out(char* PROCESS_NAME, SYSTEMIO_OUT_TYPE OUT_TYPE, char* TEXT) {
     // May be pretty stupid to make the output look pretty, but it will be way better
     // when trying to debug.
 
-    vga_print_string(("[%s/%s]: %s", PROCESS_NAME, OUT_TYPE, TEXT)); // just to be safe, double ()()
+    switch (OUT_TYPE) {
+        case 1:
+            vga_print_string(("[%s/info]: %s", PROCESS_NAME, TEXT)); // just to be safe, double ()()
+            break;
+        case 2:
+            vga_print_string(("[%s/warn]: %s", PROCESS_NAME, TEXT)); // just to be safe, double ()()
+            break;
+        case 3:
+            vga_print_string(("[%s/error]: %s", PROCESS_NAME, TEXT)); // just to be safe, double ()()
+            break;
+        case 4:
+            vga_print_string(("[%s/kernel panic]: %s", PROCESS_NAME, TEXT));
+            break;
+        default:
+            vga_print_string(("[systemio/error]: process %s invoked standard incorrectly with OUT_TYPE", PROCESS_NAME));
+            break;
+    }
 }

--- a/kernel/systemio/systemio.h
+++ b/kernel/systemio/systemio.h
@@ -1,1 +1,13 @@
-void out(char* PROCESS_NAME, char* TEXT)
+#ifndef SYSTEMIO_H_
+#define SYSTEMIO_H_
+
+enum SYSTEMIO_OUT_TYPE {
+  SYSTEMIO_OUT_INFO = 1,
+  SYSTEMIO_OUT_WARN = 2,
+  SYSTEMIO_OUT_ERROR = 3,
+  SYSTEMIO_OUT_PANIC = 4,
+};
+
+void out(char* PROCESS_NAME, SYSTEMIO_OUT_TYPE OUT_TYPE, char* TEXT)
+
+#endif


### PR DESCRIPTION
This should probably fix ``systemio`` before any build gets through.

You can invoke ``out()`` with these arguments now:
```c
out("my cool little process", SYSTEMIO_OUT_TYPE out-type, "hello world");
// here is a full collection of SYSTEMIO_OUT_TYPE

SYSTEMIO_OUT_INFO (1)
SYSTEMIO_OUT_WARN (2)
SYSTEMIO_OUT_ERROR (3)
SYSTEMIO_OUT_PANIC (4)
```

Related to #10 